### PR TITLE
feat: PRのopen時・push時にLinterを走らせる

### DIFF
--- a/.github/workflows/test_and_lint.yaml
+++ b/.github/workflows/test_and_lint.yaml
@@ -1,0 +1,20 @@
+name: test_and_lint
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths-ignore:
+      - "**.md"
+
+jobs:
+  # TODO test
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.29
+          args: --enable=golint,gosec,prealloc,gocognit


### PR DESCRIPTION
## Issues
https://github.com/ca22-game-creators/cookingbomb-server/issues/7
## About
PRのopen時・push時にLinterを走らせる
## Background
レビューする時に文法的な間違いまでみるのは大変から、その前にチェックしてもらいたい
## Details
- `.github/workflows/test_and_lint.yaml`
PRのopen時、commit時にgolangcli-lintを走らせるように
[参考](https://github.com/camphor-/relaym-server/blob/master/.github/workflows/test_and_lint.yaml#L61)
## Remarks
- 将来的にbuild/testもPR提出時にしたいので、ファイル名にはtestも含意していますす
## Preview
```
$ act pull_request
```

<img width="445" alt="スクリーンショット 2021-04-26 17 43 44" src="https://user-images.githubusercontent.com/38310693/116054742-f46d6200-a6b6-11eb-9137-96863847e983.png">
